### PR TITLE
Refactor event listeners

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,8 @@
   </main>
 
   <!-- Modal -->
-  <div class="modal hidden">
-    <button class="btn btn__close-modal close-modal">&times;</button>
+  <div class="modal hidden" data-modal>
+    <button class="btn btn__close-modal" data-close-modal>&times;</button>
     <h2>How to play</h2>
     <div class="text-container">
       <div>
@@ -50,10 +50,10 @@
       </div>
     </div>
     <div class="btn__row">
-      <button class="btn btn__modal-start close-modal">I'm ready to play!</button>
+      <button class="btn btn__modal-start" data-close-modal>I'm ready to play!</button>
     </div>
   </div>
-  <div class="overlay hidden"></div>
+  <div class="overlay hidden" data-close-modal></div>
 
   <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -106,7 +106,7 @@ document.querySelector('.btn__restart').addEventListener('click', function () {
 
 const modal = document.querySelector('.modal');
 const overlay = document.querySelector('.overlay');
-const modalClosers = document.querySelectorAll('.close-modal');
+const modalClosers = document.querySelectorAll('[data-close-modal]');
 const modalOpenerBtn = document.querySelector('.show-modal');
 
 // FUNCTIONS --------
@@ -128,8 +128,6 @@ for (let i = 0; i < modalClosers.length; i += 1) {
 }
 
 modalOpenerBtn.addEventListener('click', showModal);
-
-overlay.addEventListener('click', closeModal);
 
 // Global event listeners
 

--- a/public/script.js
+++ b/public/script.js
@@ -106,8 +106,8 @@ document.querySelector('.btn__restart').addEventListener('click', function () {
 
 const modal = document.querySelector('.modal');
 const overlay = document.querySelector('.overlay');
-const btnCloseModal = document.querySelectorAll('.close-modal');
-const btnShowModal = document.querySelector('.show-modal');
+const modalClosers = document.querySelectorAll('.close-modal');
+const modalOpenerBtn = document.querySelector('.show-modal');
 
 // FUNCTIONS --------
 
@@ -123,11 +123,11 @@ function showModal () {
 
 // EVENT LISTENERS --------
 
-for (let i = 0; i < btnCloseModal.length; i += 1) {
-  btnCloseModal[i].addEventListener('click', closeModal);
+for (let i = 0; i < modalClosers.length; i += 1) {
+  modalClosers[i].addEventListener('click', closeModal);
 }
 
-btnShowModal.addEventListener('click', showModal);
+modalOpenerBtn.addEventListener('click', showModal);
 
 overlay.addEventListener('click', closeModal);
 


### PR DESCRIPTION
- Renamed vars to match usual naming convention:
  - Renamed `btnCloseModal` to `modalClosers` to indicate that it is an array of elements that function as closers
  - Renamed `btnShowModal` to `modalOpenerBtn` to indicate that it is a `button` element
- Because `close-modal` was being used only as a selector (the 2 elements that used it have no styling in common), changed it to a data attribute
- Attached the same attribute to the overlay element & eliminated its separate `addEventListener` call